### PR TITLE
Fix: added trycatch to "open" function call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,13 @@ export class MetamaskConnector {
             serverPort: this.port
         });
 
-        open(`http://localhost:${this.port}/send-tx`, { app: { name: 'google chrome' } });
+        const url = `http://localhost:${this.port}/send-tx`;
+
+        try {
+            await open(url);
+        } catch (error) {
+            console.log("Error opening your browser, please access this URL:", url);
+        }
     }
 
 }


### PR DESCRIPTION
Me and many people don't use google chrome, so every time when i try to deploy the contract i get an error and the script exits.